### PR TITLE
feat: Add documents to order export

### DIFF
--- a/packages/order-source-api/package.json
+++ b/packages/order-source-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect-order-source-api",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "This is the typescript/javascript definitions for the order source api",
   "homepage": "https://github.com/ShipEngine/connect",
   "main": "./lib/index.js",

--- a/packages/order-source-api/src/models/document.ts
+++ b/packages/order-source-api/src/models/document.ts
@@ -1,0 +1,23 @@
+export interface Document {
+  /**
+   * Usually there will only be 1 type present, but sometimes multiple documents can be combined
+   */
+  type?: DocumentType[];
+  /**
+   * Base64 encoded string of the document in the specified format
+   */
+  data?: string;
+  format: DocumentFormat;
+}
+
+export enum DocumentType {
+  "Label" = "label",
+  "CustomsForm" = "customs_form",
+  "CommercialInvoice" = "commercial_invoice",
+}
+
+export enum DocumentFormat {
+  "Pdf" = "PDF",
+  "Zpl" = "ZPL",
+  "Png" = "PNG",
+}

--- a/packages/order-source-api/src/models/index.ts
+++ b/packages/order-source-api/src/models/index.ts
@@ -11,3 +11,4 @@ export * from "./sales-order";
 export * from "./sales-order-item";
 export * from "./shipping-preferences";
 export * from "./weight";
+export * from "./document";

--- a/packages/order-source-api/src/models/shipping-preferences.ts
+++ b/packages/order-source-api/src/models/shipping-preferences.ts
@@ -1,3 +1,5 @@
+import { Document } from "./document";
+
 export interface ShippingPreferences {
   digital_fulfillment?: boolean;
   additional_handling?: boolean;
@@ -23,4 +25,5 @@ export interface ShippingPreferences {
   premium_program_name?: string;
   /** The warehouse name associated with the requested warehouse  */
   requested_warehouse?: string;
+  documents?: Document[];
 }

--- a/packages/order-source-runtime/package.json
+++ b/packages/order-source-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect-order-source-runtime",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "This is the app host for a order source Connect app. It provides an HTTP interface implementing the OrderSourceAPI spec and does mapping to Connect and back",
   "main": "lib/server.js",
   "scripts": {

--- a/packages/order-source-runtime/src/mapping/sales-orders-export/output.ts
+++ b/packages/order-source-runtime/src/mapping/sales-orders-export/output.ts
@@ -5,7 +5,13 @@ import * as api from "@shipengine/connect-order-source-api";
 import logger from "../../util/logger";
 
 // TODO I can't find the internal export for these
-import { ChargeType, PaymentStatus, NoteType } from "@shipengine/connect-sdk";
+import {
+  ChargeType,
+  PaymentStatus,
+  NoteType,
+  DocumentType,
+  DocumentFormat,
+} from "@shipengine/connect-sdk";
 
 export function mapItem(item: Output.SalesOrderItem): api.SalesOrderItem {
   return {
@@ -32,6 +38,41 @@ export function mapItem(item: Output.SalesOrderItem): api.SalesOrderItem {
   };
 }
 
+export function mapDocument(doc: Output.Document): api.Document {
+  let format;
+  switch (doc.format) {
+    case DocumentFormat.PDF:
+      format = api.DocumentFormat.Pdf;
+      break;
+    case DocumentFormat.PNG:
+      format = api.DocumentFormat.Png;
+      break;
+    case DocumentFormat.ZPL:
+      format = api.DocumentFormat.Zpl;
+      break;
+  }
+
+  const type = [];
+  switch (doc.type) {
+    case DocumentType.CustomsForm:
+      type.push(api.DocumentType.CustomsForm);
+      break;
+    case DocumentType.Label:
+      type.push(api.DocumentType.Label);
+      break;
+    // Are these the same, but we gave them different names? Or do our enums not match?
+    case DocumentType.ScanForm:
+      type.push(api.DocumentType.CommercialInvoice);
+      break;
+  }
+
+  return {
+    type,
+    format,
+    data: doc.data.toString("base64"),
+  };
+}
+
 export function mapShippingPreferences(
   pref: Output.ShippingPreferences | undefined
 ): api.ShippingPreferences | undefined {
@@ -49,6 +90,7 @@ export function mapShippingPreferences(
     insured_value: pref.insuredValue?.value,
     is_premium_program: pref.isPremiumProgram,
     premium_program_name: pref.premiumProgramName,
+    documents: (pref.documents || []).map((doc) => mapDocument(doc)),
   };
 }
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect-sdk",
-  "version": "12.9.0",
+  "version": "12.10.0",
   "description": "The official SDK for building ShipEngine connect apps",
   "keywords": [
     "shipengine",

--- a/packages/sdk/src/internal/carriers/documents/label.ts
+++ b/packages/sdk/src/internal/carriers/documents/label.ts
@@ -1,6 +1,6 @@
 import { Label as LabelPOJO } from "../../../public";
 import { hideAndFreeze, Joi, _internal } from "../../common";
-import { Document, DocumentBase } from "./document";
+import { Document, DocumentBase } from "../../common/document";
 
 export class Label extends DocumentBase {
   public static readonly [_internal] = {

--- a/packages/sdk/src/internal/carriers/documents/utils.ts
+++ b/packages/sdk/src/internal/carriers/documents/utils.ts
@@ -1,5 +1,5 @@
 import { Document as DocumentPOJO, DocumentType } from "../../../public";
-import { Document } from "./document";
+import { Document } from "../../common/document";
 import { Label } from "./label";
 
 /**

--- a/packages/sdk/src/internal/carriers/index.ts
+++ b/packages/sdk/src/internal/carriers/index.ts
@@ -3,7 +3,6 @@ export * from "./customs/customs";
 export * from "./customs/customs-item";
 export * from "./delivery-confirmation";
 export * from "./delivery-service";
-export * from "./documents/document";
 export * from "./documents/label";
 export * from "./documents/new-label";
 export * from "./documents/utils";

--- a/packages/sdk/src/internal/carriers/manifests/manifest.ts
+++ b/packages/sdk/src/internal/carriers/manifests/manifest.ts
@@ -1,6 +1,6 @@
 import { Manifest as ManifestPOJO } from "../../../public";
 import { hideAndFreeze, Identifiers, Joi, Note, _internal } from "../../common";
-import { Document } from "../documents/document";
+import { Document } from "../../common/document";
 import { ShipmentIdentifier } from "../shipments/shipment-identifier";
 
 export class Manifest {

--- a/packages/sdk/src/internal/carriers/shipments/shipment-confirmation.ts
+++ b/packages/sdk/src/internal/carriers/shipments/shipment-confirmation.ts
@@ -1,6 +1,6 @@
 import { ShipmentConfirmation as ShipmentConfirmationPOJO } from "../../../public";
 import { calculateTotalCharges, Charge, DateTimeZone, hideAndFreeze, Joi, MonetaryValue, _internal } from "../../common";
-import { Document } from "../documents/document";
+import { Document } from "../../common/document";
 import { Label } from "../documents/label";
 import { PackageConfirmation } from "../packages/package-confirmation";
 import { ShipmentIdentifier, ShipmentIdentifierBase } from "./shipment-identifier";

--- a/packages/sdk/src/internal/common/document.ts
+++ b/packages/sdk/src/internal/common/document.ts
@@ -1,5 +1,5 @@
-import { Document as DocumentPOJO, DocumentFormat, DocumentSize, DocumentType, ErrorCode } from "../../../public";
-import { error, hideAndFreeze, Joi, _internal } from "../../common";
+import { Document as DocumentPOJO, DocumentFormat, DocumentSize, DocumentType, ErrorCode } from "../../public";
+import { error, hideAndFreeze, Joi, _internal } from ".";
 
 export abstract class DocumentBase {
   public readonly name: string;

--- a/packages/sdk/src/internal/common/index.ts
+++ b/packages/sdk/src/internal/common/index.ts
@@ -35,3 +35,4 @@ export * from "./validation";
 export * from "./validation/index";
 export * from "./validation/object-validation";
 export * from "./validation/string-validation";
+export * from "./document";

--- a/packages/sdk/src/internal/orders/shipping-preferences.ts
+++ b/packages/sdk/src/internal/orders/shipping-preferences.ts
@@ -1,5 +1,5 @@
 import { DeliveryConfirmationType, ShippingPreferences as ShippingPreferencesPOJO } from "../../public";
-import { DateTimeZone, hideAndFreeze, Joi, MonetaryValue, _internal } from "../common";
+import { Document, DateTimeZone, hideAndFreeze, Joi, MonetaryValue, _internal } from "../common";
 
 export class ShippingPreferences {
   public static readonly [_internal] = {
@@ -30,6 +30,7 @@ export class ShippingPreferences {
   public readonly isPremiumProgram: boolean;
   public readonly premiumProgramName: string;
   public readonly requestedWarehouse?: string;
+  public readonly documents?: Document[];
 
   public constructor(pojo: ShippingPreferencesPOJO) {
     this.deliveryConfirmationType = pojo.deliveryConfirmationType;
@@ -43,6 +44,7 @@ export class ShippingPreferences {
     this.isPremiumProgram = pojo.isPremiumProgram || false;
     this.premiumProgramName = pojo.premiumProgramName || "";
     this.requestedWarehouse = pojo.requestedWarehouse;
+    this.documents = (pojo.documents || []).map(doc => new Document(doc));
   
     // Make this object immutable
     hideAndFreeze(this);

--- a/packages/sdk/src/internal/output.ts
+++ b/packages/sdk/src/internal/output.ts
@@ -9,7 +9,7 @@ export { ShipmentCancellationOutcome } from "./carriers/shipments/shipment-cance
 export { ShipmentConfirmation } from "./carriers/shipments/shipment-confirmation";
 export { TrackingInfo } from "./carriers/tracking/tracking-info";
 export { Label } from "./carriers/documents/label";
-export { Document } from "./carriers/documents/document";
+export { Document } from "./common/document";
 export {
   DateTimeZone,
   Charge

--- a/packages/sdk/src/public/carriers/documents/label.ts
+++ b/packages/sdk/src/public/carriers/documents/label.ts
@@ -1,4 +1,4 @@
-import type { Document } from "./document";
+import type { Document } from "../../common/document";
 
 /**
  * A shipping label

--- a/packages/sdk/src/public/carriers/index.ts
+++ b/packages/sdk/src/public/carriers/index.ts
@@ -3,7 +3,6 @@ export * from "./customs/customs";
 export * from "./customs/customs-item";
 export * from "./delivery-confirmation";
 export * from "./delivery-service";
-export * from "./documents/document";
 export * from "./documents/label";
 export * from "./documents/new-label";
 export * from "./enums";

--- a/packages/sdk/src/public/carriers/manifests/manifest.ts
+++ b/packages/sdk/src/public/carriers/manifests/manifest.ts
@@ -1,5 +1,5 @@
 import type { Identifiers, NotePOJO } from "../../common";
-import type { Document } from "../documents/document";
+import type { Document } from "../../common/document";
 import type { ShipmentIdentifierPOJO } from "../shipments/shipment-identifier";
 
 /**

--- a/packages/sdk/src/public/carriers/shipments/shipment-confirmation.ts
+++ b/packages/sdk/src/public/carriers/shipments/shipment-confirmation.ts
@@ -1,5 +1,5 @@
 import type { ChargePOJO, DateTimeZonePOJO } from "../../common";
-import type { Document } from "../documents/document";
+import type { Document } from "../../common/document";
 import type { Label } from "../documents/label";
 import type { PackageConfirmation } from "../packages/package-confirmation";
 import type { ShipmentIdentifierPOJO } from "./shipment-identifier";

--- a/packages/sdk/src/public/common/document.ts
+++ b/packages/sdk/src/public/common/document.ts
@@ -1,4 +1,4 @@
-import type { DocumentFormat, DocumentSize, DocumentType } from "../enums";
+import type { DocumentFormat, DocumentSize, DocumentType } from "../carriers/enums";
 
 /**
  * A document that is associated with a shipment or package, such as a customs form.

--- a/packages/sdk/src/public/common/index.ts
+++ b/packages/sdk/src/public/common/index.ts
@@ -30,3 +30,4 @@ export * from "./oauth/token-properties";
 export * from "./oauth-config";
 export * from "./transaction";
 export * from "./types";
+export * from "./document";

--- a/packages/sdk/src/public/orders/shipping-preferences.ts
+++ b/packages/sdk/src/public/orders/shipping-preferences.ts
@@ -1,4 +1,5 @@
 import type { DateTimeZonePOJO, DeliveryConfirmationType, MonetaryValuePOJO } from "../common";
+import { Document } from "../common";
 
 /**
  * Preferences about how a sales order or item should be shipped
@@ -59,4 +60,9 @@ export interface ShippingPreferences {
    * The warehouse name associated with the requested warehouse.
    */
   requestedWarehouse?: string;
+
+  /**
+   * Any shipping documents the order source has for this order or package
+   */
+  documents?: Document[];
 }

--- a/website/src/pages/docs/reference/shipping-preferences.mdx
+++ b/website/src/pages/docs/reference/shipping-preferences.mdx
@@ -109,4 +109,55 @@ it is returned from a method.
     </Description>
   </Field>
 
+  <Field name="documents" type="array" required={false}>
+    <Description>
+      The digital manifest document, such as a PDF SCAN form.
+
+      This property is not required. If it is provided, it must contain all of its required properties, listed below.
+    </Description>
+  </Field>
+
+  <Field name="documents[].name" type="string" required={false}>
+    <Description>
+      The user-friendly name of the document (e.g. "Label", "Customs Form"). This string must not contain newline characters.
+    </Description>
+  </Field>
+
+  <Field name="documents[].type" type="string" required={true}>
+    <Description>
+      The type of document (e.g. label, customs form, SCAN form). Valid values include the following:
+      * `label` - label
+      * `customs_form` - customs form
+      * `scan_form` - SCAN form
+    </Description>
+  </Field>
+
+  <Field name="documents[].size" type="string" required={true}>
+    <Description>
+      The size of document (e.g. label, customs form, SCAN form). Valid values include the following:
+      * `A4`- A4 sized paper ( 8.27 inches x 11.69 inches)
+      * `letter` - Letter sized paper (8.5 inches by 11 inches)
+      * `4x6` - Paper sized 4 inches by 6 inches
+      * `4x8` - Paper sized 4 inches by 8 inches
+    </Description>
+  </Field>
+
+  <Field name="documents[].format" type="string" required={true}>
+    <Description>
+      The file format of the document. Valid values include the following:
+      * `pdf` - Portable Document Format (PDF)
+      * `zpl` - Zebra Printer Label (ZPL)
+      * `png` - Portable Graphics Format (PNG)
+    </Description>
+  </Field>
+
+  <Field name="documents[].data" required={true}>
+    <Type>
+      [Buffer object](https://nodejs.org/api/buffer.html)
+    </Type>
+    <Description>
+      The document data, in the specified file format.
+    </Description>
+  </Field>
+
 </Reference>


### PR DESCRIPTION
- adds the new documents array to the OrderSourceAPI
- moves the document interface&class into the common section of the sdk
- adds an array of documents to the shipping preferences in the sdk
- adds a mapping for the new arrays in the runtime
- updates the website to describe the documents in the preferences