### PR TITLE
feat: Add product.dimensions and salesOrder.orderNumber

### DIFF
--- a/packages/order-source-runtime/package.json
+++ b/packages/order-source-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect-order-source-runtime",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "This is the app host for a order source Connect app. It provides an HTTP interface implementing the OrderSourceAPI spec and does mapping to Connect and back",
   "main": "lib/server.js",
   "scripts": {

--- a/packages/order-source-runtime/src/mapping/sales-orders-export/output.ts
+++ b/packages/order-source-runtime/src/mapping/sales-orders-export/output.ts
@@ -11,11 +11,10 @@ import {
   NoteType,
   DocumentType,
   DocumentFormat,
-  LengthUnit
+  LengthUnit,
 } from "@shipengine/connect-sdk";
 
 export function mapItem(item: Output.SalesOrderItem): api.SalesOrderItem {
-
   const mappedItem: api.SalesOrderItem = {
     line_item_id: item.id,
     description: item.description,
@@ -44,8 +43,11 @@ export function mapItem(item: Output.SalesOrderItem): api.SalesOrderItem {
       length: item.product.dimensions.length,
       width: item.product.dimensions.width,
       height: item.product.dimensions.height,
-      unit: item.product.dimensions.unit === LengthUnit.Inches ? api.DimensionsUnit.Inch : api.DimensionsUnit.Centimeter
-    }
+      unit:
+        item.product.dimensions.unit === LengthUnit.Inches
+          ? api.DimensionsUnit.Inch
+          : api.DimensionsUnit.Centimeter,
+    };
   }
 
   return mappedItem;

--- a/packages/order-source-runtime/src/mapping/sales-orders-export/output.ts
+++ b/packages/order-source-runtime/src/mapping/sales-orders-export/output.ts
@@ -11,10 +11,12 @@ import {
   NoteType,
   DocumentType,
   DocumentFormat,
+  LengthUnit
 } from "@shipengine/connect-sdk";
 
 export function mapItem(item: Output.SalesOrderItem): api.SalesOrderItem {
-  return {
+
+  const mappedItem: api.SalesOrderItem = {
     line_item_id: item.id,
     description: item.description,
     quantity: item.quantity.value,
@@ -36,6 +38,17 @@ export function mapItem(item: Output.SalesOrderItem): api.SalesOrderItem {
     },
     item_url: item.itemURL?.toString(),
   };
+
+  if (item.product.dimensions) {
+    mappedItem.product!.dimensions = {
+      length: item.product.dimensions.length,
+      width: item.product.dimensions.width,
+      height: item.product.dimensions.height,
+      unit: item.product.dimensions.unit === LengthUnit.Inches ? api.DimensionsUnit.Inch : api.DimensionsUnit.Centimeter
+    }
+  }
+
+  return mappedItem;
 }
 
 export function mapDocument(doc: Output.Document): api.Document {
@@ -254,6 +267,7 @@ export function mapSalesOrder(order: Output.SalesOrder): api.SalesOrder {
 
   return {
     order_id: order.id,
+    order_number: order.orderNumber,
     status: mapSalesOrderStatus(order.status),
     requested_fulfillments: order.requestedFulfillments.map(mapRequestedFulfillment),
     buyer: mapBuyer(order.buyer),

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect-sdk",
-  "version": "12.10.0",
+  "version": "12.11.0",
   "description": "The official SDK for building ShipEngine connect apps",
   "keywords": [
     "shipengine",

--- a/packages/sdk/src/internal/common/measures/dimensions.ts
+++ b/packages/sdk/src/internal/common/measures/dimensions.ts
@@ -1,5 +1,4 @@
 import { Dimensions as IDimensions, DimensionsPOJO, LengthUnit } from "../../../public";
-import { error, SystemErrorCode } from "../errors";
 import { hideAndFreeze, _internal } from "../utils";
 import { Joi } from "../validation";
 
@@ -21,23 +20,10 @@ export class Dimensions implements IDimensions {
 
   public constructor(pojo: DimensionsPOJO) {
 
-    this.length = pojo.length;
-    this.width = pojo.width;
-    this.height = pojo.height;
+    this.length = pojo.length || 0;
+    this.width = pojo.width || 0;
+    this.height = pojo.height || 0;
     this.unit = pojo.unit;
-
-    // Check that at least two of the three dimensions properties are set. (Allows for 2 dimensional packages such as envelopes)
-    const zeroCount = [this.length, this.width, this.height].reduce((totalCount, currentValue) => {
-      if(!currentValue) {
-        return totalCount + 1;
-      }
-      return totalCount;
-    }, 0);
-
-    if (zeroCount > 1) {
-      const message = "Dimensions property must have at least 2 of the 3 length, width, and height properties set.";
-      throw error(SystemErrorCode.InvalidInput, message);
-    }
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/packages/sdk/src/internal/products/product-identifier.ts
+++ b/packages/sdk/src/internal/products/product-identifier.ts
@@ -1,5 +1,5 @@
-import { ProductIdentifier as IProductIdentifier, ProductIdentifierPOJO } from "../../public";
-import { hideAndFreeze, Identifiers, Joi, _internal } from "../common";
+import { ProductIdentifier as IProductIdentifier, ProductIdentifierPOJO, DimensionsPOJO } from "../../public";
+import { hideAndFreeze, Identifiers, Dimensions, Joi, _internal } from "../common";
 
 
 export class ProductIdentifier implements IProductIdentifier {
@@ -27,6 +27,7 @@ export class ProductIdentifier implements IProductIdentifier {
   public readonly inventoryID: string;
   public readonly identifiers: Identifiers;
   public readonly details: Identifiers;
+  public readonly dimensions?: Dimensions;
 
   public constructor(pojo: ProductIdentifierPOJO) {
     this.id = pojo.id;
@@ -38,6 +39,7 @@ export class ProductIdentifier implements IProductIdentifier {
     this.inventoryID = pojo.inventoryID || "";
     this.details = new Identifiers(pojo.details)
     this.identifiers = new Identifiers(pojo.identifiers);
+    this.dimensions = pojo.dimensions ? new Dimensions(pojo.dimensions) : undefined;
 
     // Make this object immutable
     hideAndFreeze(this);

--- a/packages/sdk/src/public/common/measures/dimensions.ts
+++ b/packages/sdk/src/public/common/measures/dimensions.ts
@@ -10,9 +10,9 @@ export enum LengthUnit {
  * The dimensions of a package
  */
 export interface DimensionsPOJO {
-  length: number;
-  width: number;
-  height: number;
+  length?: number;
+  width?: number;
+  height?: number;
   unit: LengthUnit;
 }
 

--- a/packages/sdk/src/public/products/product-identifier.ts
+++ b/packages/sdk/src/public/products/product-identifier.ts
@@ -1,4 +1,4 @@
-import type { Identifiers, IdentifiersPOJO } from "../common";
+import type { Identifiers, IdentifiersPOJO, Dimensions, DimensionsPOJO } from "../common";
 
 /**
  * Identifies a product
@@ -49,6 +49,11 @@ export interface ProductIdentifierPOJO {
    * { "Color": "White", "Style": "Avant Garde" }
    */
   details?: IdentifiersPOJO;
+
+  /**
+   * The physical measures of the product
+   */
+  dimensions?: DimensionsPOJO;
 }
 
 /**
@@ -100,4 +105,9 @@ export interface ProductIdentifier {
    * { "Color": "White", "Style": "Avant Garde" }
    */
   readonly details: Identifiers;
+
+  /**
+   * The physical measures of the product
+   */
+  readonly dimensions?: Dimensions;
 }

--- a/website/src/pages/docs/reference/methods/get-sales-orders-by-date.mdx
+++ b/website/src/pages/docs/reference/methods/get-sales-orders-by-date.mdx
@@ -164,8 +164,8 @@ An array of sales orders matching the date range.
 
   <Field name="orderNumber" type="string" required={false}>
     <Description>
-      Use this field when a marketplace provides a human readible number or identifier for orders that's
-      different from that order's unique id.
+      Use this field when a marketplace provides a customer facing identifier for the order that
+      is different from that order's unique id.
     </Description>
   </Field>
 

--- a/website/src/pages/docs/reference/methods/get-sales-orders-by-date.mdx
+++ b/website/src/pages/docs/reference/methods/get-sales-orders-by-date.mdx
@@ -162,6 +162,13 @@ An array of sales orders matching the date range.
     </Description>
   </Field>
 
+  <Field name="orderNumber" type="string" required={false}>
+    <Description>
+      Use this field when a marketplace provides a human readible number or identifier for orders that's
+      different from that order's unique id.
+    </Description>
+  </Field>
+
   <Field name="createdDateTime" required={true}>
     <Type>
       [Date Time](./../date-time.mdx), <br/>

--- a/website/src/pages/docs/reference/sales-order-item.mdx
+++ b/website/src/pages/docs/reference/sales-order-item.mdx
@@ -22,12 +22,6 @@ not passed as an argument to any method.
     </Description>
   </Field>
 
-  <Field name="orderNumber" type="string" required={false}>
-    <Description>
-      The customer facing identifier of the sales order.
-    </Description>
-  </Field>
-
   <Field name="name" type="string" required={true}>
     <Description>
       The user-friendly name of the item. This is often the same as the product name. This string must not contain newline characters.

--- a/website/src/pages/docs/reference/sales-order-item.mdx
+++ b/website/src/pages/docs/reference/sales-order-item.mdx
@@ -100,6 +100,38 @@ not passed as an argument to any method.
     </Description>
   </Field>
 
+  <Field name="product.dimensions" type="object" required={false}>
+     <Description>
+       The dimensions for the product.
+     </Description>
+  </Field>
+
+  <Field name="product.dimensions.length" type="number" required={false}>
+    <Description>
+      The length of the product. This value may contain decimals.
+    </Description>
+  </Field>
+
+  <Field name="product.dimensions.width" type="number" required={false}>
+    <Description>
+      The width of the product. This value may contain decimals.
+    </Description>
+  </Field>
+
+  <Field name="product.dimensions.height" type="number" required={false}>
+    <Description>
+      The height of the product. This value may contain decimals.
+    </Description>
+  </Field>
+
+  <Field name="product.dimensions.unit" type="string" required={true}>
+    <Description>
+      The unit of measurement for the dimensions. Valid values include the following:
+      * `in` - inches
+      * `cm` - centimeters
+    </Description>
+  </Field>
+
   <Field name="quantity" type="object" required={true}>
     <Description>
       The quantity of this item in the sales order.


### PR DESCRIPTION
The SDK already had a set of `Dimensions` objects that were being used for Carrier stuff, so I relaxed the validation on them a bit and added them to the `Product` interface. Products in OrderSourceAPI already had dimensions, so the mapping is straightforward.

Both the SDK and OrderSourceAPI had `orderNumber` already, but it wasn't in the runtime mappings and the docs had it on order _items_ instead of orders. Technically, removing the field that was only ever in the docs isn't a breaking change, so 🔪 