### PR TITLE
fix: remove unneeded 'contact' object from address docs

### DIFF
--- a/website/src/pages/docs/reference/address.mdx
+++ b/website/src/pages/docs/reference/address.mdx
@@ -248,37 +248,37 @@ column indicates which properties are required when the object is returned from 
     </Description>
   </Field>
 
-  <Field name="contact.name" type="object" nullable={false} required={true}>
+  <Field name="name" type="object" nullable={false} required={true}>
     <Description>
       The name of the contact.
     </Description>
   </Field>
 
-  <Field name="contact.name.title" type="string" nullable={false} required={false}>
+  <Field name="name.title" type="string" nullable={false} required={false}>
     <Description>
       The title of the contact (eg "Mr", "Mrs", "Dr"). This string must not include newline characters.
     </Description>
   </Field>
 
-  <Field name="contact.name.given" type="string" nullable={false} required={true}>
+  <Field name="name.given" type="string" nullable={false} required={true}>
     <Description>
       The first name of the signer. This string must not include newline characters.
     </Description>
   </Field>
 
-  <Field name="contact.name.middle" type="string" nullable={false} required={false}>
+  <Field name="name.middle" type="string" nullable={false} required={false}>
     <Description>
       The middle name of the signer. This string must not include newline characters.
     </Description>
   </Field>
 
-  <Field name="contact.name.family" type="string" nullable={false} required={false}>
+  <Field name="name.family" type="string" nullable={false} required={false}>
     <Description>
       The last name or family name of the signer. This string must not include newline characters.
     </Description>
   </Field>
 
-  <Field name="contact.name.suffix" type="string" nullable={false} required={false}>
+  <Field name="name.suffix" type="string" nullable={false} required={false}>
     <Description>
       The suffix of the signer (eg "Sr", "Jr", "IV"). This string must not include newline characters.
     </Description>
@@ -376,37 +376,37 @@ returned from one of your methods.
     </Description>
   </Field>
 
-  <Field name="contact.name" type="object" nullable={false} required={true}>
+  <Field name="name" type="object" nullable={false} required={true}>
     <Description>
       The name of the contact.
     </Description>
   </Field>
 
-  <Field name="contact.name.title" type="string" nullable={false} required={false}>
+  <Field name="name.title" type="string" nullable={false} required={false}>
     <Description>
       The title of the contact (eg "Mr", "Mrs", "Dr"). This string must not include newline characters.
     </Description>
   </Field>
 
-  <Field name="contact.name.given" type="string" nullable={false} required={true}>
+  <Field name="name.given" type="string" nullable={false} required={true}>
     <Description>
       The first name of the signer. This string must not include newline characters.
     </Description>
   </Field>
 
-  <Field name="contact.name.middle" type="string" nullable={false} required={false}>
+  <Field name="name.middle" type="string" nullable={false} required={false}>
     <Description>
       The middle name of the signer. This string must not include newline characters.
     </Description>
   </Field>
 
-  <Field name="contact.name.family" type="string" nullable={false} required={false}>
+  <Field name="name.family" type="string" nullable={false} required={false}>
     <Description>
       The last name or family name of the signer. This string must not include newline characters.
     </Description>
   </Field>
 
-  <Field name="contact.name.suffix" type="string" nullable={false} required={false}>
+  <Field name="name.suffix" type="string" nullable={false} required={false}>
     <Description>
       The suffix of the signer (eg "Sr", "Jr", "IV"). This string must not include newline characters.
     </Description>


### PR DESCRIPTION
https://connect.shipengine.com/docs/reference/address#address-contact-info-properties

https://github.com/ShipEngine/connect/blob/master/packages/sdk/src/public/common/addresses/address-with-contact-info.ts


Address with contact info docs are incorrect. They introduce an unneeded `contact` object, when `name` needs to live on the address itself. This PR removes that unneeded nesting.