### PR TITLE
Improve single currency logic

### DIFF
--- a/.yarn/versions/f6fea974.yml
+++ b/.yarn/versions/f6fea974.yml
@@ -1,2 +1,3 @@
 releases:
+  "@shipengine/connect": patch
   "@shipengine/connect-order-source-runtime": patch

--- a/.yarn/versions/f6fea974.yml
+++ b/.yarn/versions/f6fea974.yml
@@ -1,3 +1,0 @@
-releases:
-  "@shipengine/connect": patch
-  "@shipengine/connect-order-source-runtime": patch

--- a/.yarn/versions/f6fea974.yml
+++ b/.yarn/versions/f6fea974.yml
@@ -1,0 +1,2 @@
+releases:
+  "@shipengine/connect-order-source-runtime": patch

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "The official developer tooling for building ShipEngine connect apps",
   "keywords": [
     "shipengine",
@@ -120,7 +120,7 @@
     "@oclif/plugin-not-found": "^1.2.4",
     "@shipengine/capitalization": "^1.2.1",
     "@shipengine/connect-loader": "^3.4.0",
-    "@shipengine/connect-order-source-runtime": "^1.7.2",
+    "@shipengine/connect-order-source-runtime": "^1.7.3",
     "@shipengine/connect-sdk": "^12.13.0",
     "@shipengine/connect-shipping-runtime": "^1.4.1",
     "axios": "^0.21.1",

--- a/packages/order-source-runtime/package.json
+++ b/packages/order-source-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipengine/connect-order-source-runtime",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "This is the app host for a order source Connect app. It provides an HTTP interface implementing the OrderSourceAPI spec and does mapping to Connect and back",
   "main": "lib/server.js",
   "scripts": {

--- a/packages/order-source-runtime/src/mapping/sales-orders-export/output.ts
+++ b/packages/order-source-runtime/src/mapping/sales-orders-export/output.ts
@@ -289,18 +289,18 @@ export function mapSalesOrderStatus(status: Output.SalesOrderStatus): api.SalesO
 }
 
 export function getSingleCurrency(order: Output.SalesOrder): string {
-  let currency: string | undefined = undefined;
-
   // We're going to check the line item currencies first because they're the most likely to exist
-  order.requestedFulfillments.forEach((fill) => {
-    fill.items.forEach((item) => {
-      currency ||= item.unitPrice.currency
-    });
-  });
+  for (const fill of order.requestedFulfillments) {
+    for (const item of fill.items) {
+      if (item.unitPrice.currency) {
+        return item.unitPrice.currency;
+      }
+    }
+  }
 
   // If we didn't pick up a currency from the line items, use the currency on totalCharges
   // We don't need to provide a fallback, because totalCharges.currency already defaults to USD
-  return currency || order.totalCharges.currency
+  return order.totalCharges.currency;
 }
 
 export function mapSalesOrder(order: Output.SalesOrder): api.SalesOrder {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,7 +1226,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@shipengine/connect-order-source-runtime@^1.7.2, @shipengine/connect-order-source-runtime@workspace:packages/order-source-runtime":
+"@shipengine/connect-order-source-runtime@^1.7.3, @shipengine/connect-order-source-runtime@workspace:packages/order-source-runtime":
   version: 0.0.0-use.local
   resolution: "@shipengine/connect-order-source-runtime@workspace:packages/order-source-runtime"
   dependencies:
@@ -1353,7 +1353,7 @@ __metadata:
     "@oclif/test": ^1.2.8
     "@shipengine/capitalization": ^1.2.1
     "@shipengine/connect-loader": ^3.4.0
-    "@shipengine/connect-order-source-runtime": ^1.7.2
+    "@shipengine/connect-order-source-runtime": ^1.7.3
     "@shipengine/connect-sdk": ^12.13.0
     "@shipengine/connect-shipping-runtime": ^1.4.1
     "@types/chai": ^4.2.14


### PR DESCRIPTION
The previous version of this was pulling the OrderSourceAPI currency code off of the SDK's `SalesOrder.totalCharges`, [which is calculated from the order level charges array](https://github.com/ShipEngine/connect/blob/master/packages/sdk/src/internal/orders/sales-order.ts#L61), _but_ orders aren't guaranteed to have charges at the top level if there aren't any cost adjustments on top of the line item prices. In this case, [the SDK sends `usd` by default](https://github.com/ShipEngine/connect/blob/81bbbe38ec0c107d2bf7ac109dded7084f7d7294/packages/sdk/src/internal/common/measures/monetary-value.ts#L56) which is dangerous for non-🇺🇸 integrations.

So rather than relying on `totalCharges` this changes it so that we prefer to pull a currency code off of a line item before looking at the total.